### PR TITLE
Updated scripts to use System Views instead of internal pg tables

### DIFF
--- a/yb_get_table_names.py
+++ b/yb_get_table_names.py
@@ -31,6 +31,9 @@ class get_table_names:
             "<schema_column_name> || '.' || <object_column_name>"
             if common.args.schemas else '<object_column_name>')
 
+        sys_user = ("""JOIN <database_name>.sys.user AS u
+        ON t.owner_id = u.user_id""" if common.args.owner else "")
+
         sql_query = (("""
 SELECT
     %s
@@ -38,11 +41,10 @@ FROM
     <database_name>.sys.table AS t
     JOIN <database_name>.sys.schema AS s
         ON t.schema_id = s.schema_id
-    JOIN <database_name>.sys.user AS u
-        ON t.owner_id = u.user_id
+    %s
 WHERE
     %s
-ORDER BY 1""" % (object_name_clause, common.filter_clause))
+ORDER BY 1""" % (object_name_clause, sys_user, common.filter_clause))
                      .replace('<owner_column_name>', 'u.name')
                      .replace('<schema_column_name>', 's.name')
                      .replace('<object_column_name>', 't.name')

--- a/yb_get_table_names.py
+++ b/yb_get_table_names.py
@@ -35,15 +35,17 @@ class get_table_names:
 SELECT
     %s
 FROM
-    <database_name>.information_schema.tables AS t
-    JOIN <database_name>.pg_catalog.pg_tables AS c
-        ON (t.table_name = c.tablename AND t.table_schema = c.schemaname)
+    <database_name>.sys.table AS t
+    JOIN <database_name>.sys.schema AS s
+        ON t.schema_id = s.schema_id
+    JOIN <database_name>.sys.user AS u
+        ON t.owner_id = u.user_id
 WHERE
-    t.table_type='BASE TABLE' AND %s
+    %s
 ORDER BY 1""" % (object_name_clause, common.filter_clause))
-                     .replace('<owner_column_name>', 'c.tableowner')
-                     .replace('<schema_column_name>', 't.table_schema')
-                     .replace('<object_column_name>', 't.table_name')
+                     .replace('<owner_column_name>', 'u.name')
+                     .replace('<schema_column_name>', 's.name')
+                     .replace('<object_column_name>', 't.name')
                      .replace('<database_name>', common.database))
 
         cmd_results = common.ybsql_query(sql_query)

--- a/yb_get_view_names.py
+++ b/yb_get_view_names.py
@@ -34,15 +34,19 @@ class get_view_names:
 
         sql_query = (("""
 SELECT
-    """ + object_name_clause + """
+    %s
 FROM
-    <database_name>.pg_catalog.pg_views AS v
+    <database_name>.sys.view AS v
+    JOIN <database_name>.sys.schema AS s
+        ON v.schema_id = s.schema_id
+    JOIN <database_name>.sys.user AS u
+        ON v.owner_id = u.user_id
 WHERE
     %s
-ORDER BY 1""" % common.filter_clause)
-                     .replace('<owner_column_name>', 'v.viewowner')
-                     .replace('<schema_column_name>', 'v.schemaname')
-                     .replace('<object_column_name>', 'v.viewname')
+ORDER BY 1""" % (object_name_clause, common.filter_clause))
+                     .replace('<owner_column_name>', 'u.name')
+                     .replace('<schema_column_name>', 's.name')
+                     .replace('<object_column_name>', 'v.name')
                      .replace('<database_name>', common.database))
 
         cmd_results = common.ybsql_query(sql_query)

--- a/yb_get_view_names.py
+++ b/yb_get_view_names.py
@@ -32,6 +32,9 @@ class get_view_names:
             "<schema_column_name> || '.' || <object_column_name>"
             if common.args.schemas else '<object_column_name>')
 
+        sys_user = ("""JOIN <database_name>.sys.user AS u
+        ON v.owner_id = u.user_id""" if common.args.owner else "")
+
         sql_query = (("""
 SELECT
     %s
@@ -39,11 +42,10 @@ FROM
     <database_name>.sys.view AS v
     JOIN <database_name>.sys.schema AS s
         ON v.schema_id = s.schema_id
-    JOIN <database_name>.sys.user AS u
-        ON v.owner_id = u.user_id
+    %s
 WHERE
     %s
-ORDER BY 1""" % (object_name_clause, common.filter_clause))
+ORDER BY 1""" % (object_name_clause, sys_user, common.filter_clause))
                      .replace('<owner_column_name>', 'u.name')
                      .replace('<schema_column_name>', 's.name')
                      .replace('<object_column_name>', 'v.name')


### PR DESCRIPTION
Updated the sql queries in two scripts (yb_get_table_names, yb_get_view_names)
to utilize yellowbrick system views instead of internal pg tables. Functionality
is unchanged, but the means to achieve the result have changed.