### PR TITLE
replica_bulk_action_p: filter _replicas on r.name, not the select list alias

### DIFF
--- a/sql/sysviews_yb5/replica_bulk_action_p.sql
+++ b/sql/sysviews_yb5/replica_bulk_action_p.sql
@@ -14,6 +14,8 @@
 **   Yellowbrick Data Corporation shall have no liability whatsoever.
 **
 ** Revision History:
+** . 2026.08.13 - Filter _replicas on r.name; replica_name is a select list
+**                alias and is not in scope in the WHERE clause.
 */
 
 /* ****************************************************************************
@@ -86,7 +88,7 @@ BEGIN
         FOREACH v_replica IN ARRAY string_to_array(_replicas, '|') LOOP
             v_replica_in_list := v_replica_in_list || quote_literal(TRIM(v_replica)) || ',';
         END LOOP;
-        v_replica_in_list := 'replica_name IN (' || RTRIM(v_replica_in_list, ',') || ')';
+        v_replica_in_list := 'r.name IN (' || RTRIM(v_replica_in_list, ',') || ')';
         v_status = 'TRUE';
     ELSE
         v_replica_in_list := 'TRUE';


### PR DESCRIPTION
This PR proposes fixing the `_replicas` filter in `replica_bulk_action_p`, which builds its predicate against the select list alias `replica_name` and so aborts every call that supplies the parameter. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/296. You can sign in with your GitHub ID to claim ownership of the project.

`replica_bulk_action_p` assembles its replica lookup as `SELECT d.name AS db_name, r.name AS replica_name FROM sys.REPLICA AS r JOIN sys.database AS d USING (database_id) WHERE ...`, and when `_replicas` is supplied it appends the predicate `replica_name IN (...)`. `replica_name` only exists as a select list alias, so it is not in scope in `WHERE`, and the whole statement fails before a single line of script is emitted. `sys.replica` exposes the column as `name` — which is how `log_replica_p` and `backup_chains_p` read it in this same directory — so the predicate has to be qualified the way the surrounding ones already are.

The three `_replicas` examples in the procedure's own `COMMENT ON FUNCTION` hit this, so the quickest check on a cluster that already has sysviews installed is any call that passes the parameter:

```
SELECT * FROM replica_bulk_action_p(_action := 'PAUSE', _replicas := 'anything');
ERROR:  column "replica_name" does not exist
LINE 5:     AND replica_name IN ('anything')
                ^
QUERY:  SELECT d.name AS db_name, r.name AS replica_name
FROM sys.REPLICA AS r JOIN sys.database AS d USING (database_id)
WHERE
    TRUE
    AND replica_name IN ('anything')
    AND TRUE
ORDER BY replica_name
```

The change is one identifier — `'replica_name IN ('` becomes `'r.name IN ('` — plus a Revision History line. To confirm it at `master` and check nothing else moved, I ran the procedure body against stub `sys.replica` and `sys.database` tables on stock PostgreSQL; only the `CREATE` header and the `ybd_query_tags` setting name differ there, the script-building loop runs as written. Before the change, the two calls that pass `_replicas` raised the error above and the two that do not (no filter, and the `--replica_like '%'` form the CLI generates) produced script; after it, all four produce script and the output of the two that already worked is byte-identical. I also exercised the edges this predicate touches: a named replica whose status is not `RUNNING` is now reachable through the documented override, whitespace around names is trimmed, an unknown name yields an empty script rather than an error, `_replicas` and `_yb_util_filter` combine, quoting still neutralises a name carrying `') OR (1=1`, and an invalid `_action` is still rejected. `bin/yb_sysprocs_replica_bulk_action.py` never passes `_replicas`, so no CLI invocation changes behaviour. I did not add a case under `test/`, since that harness runs against a live instance and there is no existing coverage for the replica procedures to extend.

## How this was managed

This work was tracked as a single story, [_replicas filter fails with "column replica_name does not exist"](https://eastagiletracker.com/projects/296/stories/187955), on a board imported from this repository's own issues and pull requests — 71 stories in all — which is also where the reproduction and verification notes above were kept while the change was made.

![board](https://raw.githubusercontent.com/eastagiletracker/YbEasyCli/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
